### PR TITLE
Fix Issue #113: Task Sorting Part 2, The Sequel

### DIFF
--- a/frontend/components/TaskColumns.jsx
+++ b/frontend/components/TaskColumns.jsx
@@ -18,7 +18,11 @@ export const taskColumns = [
                 <TaskHeaderButton column={column} onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>Task Name</TaskHeaderButton>
             )
           },
-        sortingFns: "alphanumericCaseSensitive",
+        sortingFn: (rowA, rowB) => {
+          const nameA = rowA.getValue('title').toLowerCase();
+          const nameB = rowB.getValue('title').toLowerCase();
+          return nameA.localeCompare(nameB);
+        },
     },
     {
         accessorKey: "project",

--- a/frontend/components/TaskColumnsDeleted.jsx
+++ b/frontend/components/TaskColumnsDeleted.jsx
@@ -18,7 +18,11 @@ export const taskColumnsDeleted = [
                 <TaskHeaderButton column={column} onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>Task Name</TaskHeaderButton>
             )
         },
-        sortingFns: "alphanumericCaseSensitive",
+        sortingFn: (rowA, rowB) => {
+            const nameA = rowA.getValue('title').toLowerCase();
+            const nameB = rowB.getValue('title').toLowerCase();
+            return nameA.localeCompare(nameB);
+        },
     },
     {
         accessorKey: "project",


### PR DESCRIPTION
- Add custom function to sort task names alphanumerically, while not separating by case.
- Apply sort function to all task pages

![image](https://github.com/user-attachments/assets/215f67d6-79c5-46c0-bdb1-8004c651f4c9)
