### PR TITLE
switch projects to useContext

### DIFF
--- a/frontend/components/ProjectAccordion.jsx
+++ b/frontend/components/ProjectAccordion.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from "react";
+import React, { useContext } from "react";
 import {
     Accordion,
     AccordionContent,
@@ -8,63 +8,11 @@ import {
 import {Button} from "./ui/button";
 import NavButton from "./NavButton";
 import {PlusIcon, TrashIcon} from "@radix-ui/react-icons";
+import { ProjectContext } from "@/lib/taskProjectUtils";
 import {Trash2Icon} from "lucide-react";
 
 function ProjectAccordion() {
-    const [projects, setProjects] = useState([]);
-
-    const fetchProjects = async () => {
-        try {
-            const response = await fetch('/projects');
-            if (response.ok) {
-                const projectData = await response.json();
-                setProjects(projectData);
-            } else {
-                console.error("Failed to fetch projects:", response.statusText);
-            }
-        } catch (error) {
-            console.error("Error fetching projects:", error);
-        }
-    };
-
-    useEffect(() => {
-        fetchProjects();
-    }, []);
-
-    const deleteProject = async (projectID) => {
-        try {
-            const response = await fetch(`/projects/${projectID}`, {method: 'DELETE'});
-            if (response.ok) {
-                setProjects(prevTasks => prevTasks.filter(projects => projects.id !== projectID));
-            } else {
-                console.log(`Error deleting task ${projectID}`);
-            }
-        } catch (e) {
-            console.error(e.message);
-        }
-    };
-
-    const addProject = async () => {
-        const nextId = projects.length > 0 ? Math.max(...projects.map(p => p.id)) + 1 : 1;
-        const projectName = `Project ${nextId}`;
-
-        let response = await fetch('/projects', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({
-                name: projectName,
-            })
-        });
-
-        if (response.ok) {
-            const newProject = await response.json();
-            console.log('Created new project:', newProject);
-            setProjects(prevProjects => [...prevProjects, newProject]);
-        } else {
-            console.log('POST /projects failed to respond');
-        }
-    };
-
+    const { projects, deleteProject, addProject } = useContext(ProjectContext);
 
     return (
         <Accordion defaultValue="projects" type="single" collapsible>
@@ -79,7 +27,7 @@ function ProjectAccordion() {
                     >
                         {/* added onclick to svg */}
                         <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg"
-                             onClick={addProject}>
+                             onClick={() => addProject()}>
                             {/* replaced <addProjectpath with <path*/}
                             <path
                                 d="M8 2.75C8 2.47386 7.77614 2.25 7.5 2.25C7.22386 2.25 7 2.47386 7 2.75V7H2.75C2.47386 7 2.25 7.22386 2.25 7.5C2.25 7.77614 2.47386 8 2.75 8H7V12.25C7 12.5261 7.22386 12.75 7.5 12.75C7.77614 12.75 8 12.5261 8 12.25V8H12.25C12.5261 8 12.75 7.77614 12.75 7.5C12.75 7.22386 12.5261 7 12.25 7H8V2.75Z"
@@ -92,14 +40,14 @@ function ProjectAccordion() {
                 </div>
                 <AccordionContent className="">
                     <ul className="flex flex-col gap-1 -mx-2 -mb-2">
-                        {projects.map((project) => (
+                        {projects ? projects.map((project) => (
                             <li key={project.id} className="relative grid grid-cols-[99%_1%] gap-2 items-center">
                                 {/* Project Name */}
                                 <NavButton href={`/project/${project.id}`}
                                            className="flex items-center justify-between w-full">
-        <span className="flex items-center justify-between w-full pr-4">
-            <span>{project.name}</span>
-        </span>
+                                    <span className="flex items-center justify-between w-full pr-4">
+                                        <span>{project.name}</span>
+                                    </span>
                                 </NavButton>
 
                                 {/* Trash Icon with Absolute Position */}
@@ -110,7 +58,7 @@ function ProjectAccordion() {
                                 </button>
                             </li>
 
-                        ))}
+                        )) : <></>}
                     </ul>
                 </AccordionContent>
             </AccordionItem>

--- a/frontend/components/ProjectProvider.jsx
+++ b/frontend/components/ProjectProvider.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react'
+import { authAndFetchProjects, post, ProjectContext } from '@/lib/taskProjectUtils'
+import { useLocation } from 'react-router-dom'
+
+export default function ProjectProvider({children}) {
+    const [projects, setProjects] = useState(null)
+    const location = useLocation()
+
+    const createDefaultProject = async () => {
+        try {
+            const response = await post('/projects', {name: 'Default Project' })
+            if (!response.ok)
+                throw new Error(`[${response.status}] ${response.statusText}`)
+            const project = await response.json()
+            setProjects([project])
+        } catch (e) {
+            console.error('Error creating default project: ', e)
+        }
+    }
+
+    useEffect(() => {
+        authAndFetchProjects(setProjects)
+    }, [location])
+
+    useEffect(() => {
+        if (projects == null)
+            return
+        if (projects.length === 0)
+            createDefaultProject()
+    }, [projects])
+
+    const addProject = async projectName => {
+        const nextId = projects.length > 0 ? Math.max(...projects.map(p => p.id)) + 1 : 1
+        const name = projectName ? projectName : `Project ${nextId}`
+        const response = await post('/projects', { name })
+        if (response.ok) {
+            const newProject = await response.json()
+            console.log('Created new project:', newProject)
+            setProjects(prevProjects => [...prevProjects, newProject])
+        } else {
+            console.log('POST /projects failed to respond')
+        }
+    };
+
+    const deleteProject = async projectID => {
+        try {
+            const response = await fetch(`/projects/${projectID}`, {method: 'DELETE'})
+            if (response.ok) {
+                setProjects(prevTasks => prevTasks.filter(projects => projects.id !== projectID))
+                if (window.location.pathname == `/project/${projectID}`)
+                    window.location.replace('/')
+            } else {
+                console.log(`Error deleting task ${projectID}`)
+            }
+        } catch (e) {
+            console.error(e.message)
+        }
+    };
+
+    return (
+        <ProjectContext.Provider value={{ projects, deleteProject, addProject }}>
+            {children}
+        </ProjectContext.Provider>
+    )
+}

--- a/frontend/components/TaskSidePanel.jsx
+++ b/frontend/components/TaskSidePanel.jsx
@@ -89,6 +89,10 @@ export const TaskSidePanel = ({selectedTask, setTasks, projects, selectedProject
         document.getElementById('priority-option').value = selectedTask.priority
     }, [selectedTask])
 
+    useEffect(() => {
+        if (selectedProject)
+            document.getElementById('projects-option').value = selectedProject.id
+    }, [selectedProject])
 
     return (
         <>

--- a/frontend/lib/taskProjectUtils.js
+++ b/frontend/lib/taskProjectUtils.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export const fetchWithJson = async (endpoint, method, payload) => {
     return await fetch(endpoint, {
         method,
@@ -24,7 +26,8 @@ export const fetchProjects = async setProjectsFn => {
 
 export const authAndFetchProjects = async setProjectsFn => {
     if (!(await fetch('/auth')).ok) {
-        window.location.replace('/login')
+        if (window.location.pathname !== '/login')
+            window.location.replace('/login')
         return;
     }
     fetchProjects(setProjectsFn)
@@ -73,3 +76,5 @@ export const formatTasks = (taskMap, projects, selectedProject) => {
         }
     })
 }
+
+export const ProjectContext = React.createContext(null)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,20 +6,18 @@ import {Register} from './pages/Registration'
 import PageLayout from './pages/Layout'
 import SharedWithMe from './pages/SharedWithMe'
 import ProjectPage from './pages/ProjectPage';
-import {SidePanel} from "@/components/SidePanel.jsx";
-import {Sidebar} from "@/components/ui/sidebar.jsx";
 import RecentlyDeleted from "@/src/pages/RecentlyDeleted.jsx";
+import ProjectProvider from "@/components/ProjectProvider";
 
 export default function Component() {
     return (
         <>
             <BrowserRouter>
                 <Routes>
-                    <Route path="/" element={<PageLayout/>}>
+                    <Route path="/" element={<ProjectProvider><PageLayout/></ProjectProvider>}>
                         <Route index element={<TaskPage/>}/>
                         <Route path="deleted" element={<RecentlyDeleted/>}/>
                         <Route path="shared" element={<SharedWithMe/>}/>
-                        {/*<Route path="project" element={<ProjectPage/>}/>*/}
                         <Route path="project/:projectID" element={<ProjectPage/>}/>
                     </Route>
                     <Route path="/Login" element={<Login/>}/>

--- a/frontend/src/pages/TaskPage.jsx
+++ b/frontend/src/pages/TaskPage.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react'
-import { authAndFetchProjects, fetchTasks, formatTasks } from '@/lib/taskProjectUtils'
+import React, { useContext, useEffect, useState } from 'react'
+import { fetchTasks, formatTasks, ProjectContext } from '@/lib/taskProjectUtils'
 
 import { Button } from '@/components/ui/button'
 import { TaskTable } from '@/components/TaskTable'
@@ -17,30 +17,11 @@ const isPresent = num => !!num || num === 0
 export const TaskPage = ({projectId}) => {
     const [pageTitle, setPageTitle] = useState(isPresent(projectId) ? 'Project' : 'My Tasks')
     const [tasks, setTasks] = useState({})
-    const [projects, setProjects] = useState(null)
+    const { projects } = useContext(ProjectContext)
     const [selectedProject, setSelectedProject] = useState(null)
     const [activeTab, setActiveTab] = useState("upcoming")
     const [lastSelectedTask, setLastSelectedTask] = useState(null)
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-
-    const createDefaultProject = async () => {
-        try {
-            const response = await fetch('/projects', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({name: 'Default Project', description: ''})
-            })
-            if (!response.ok)
-                throw new error(`[${response.status}] ${response.statusText}`)
-            const project = await response.json()
-            setProjects([project])
-            setSelectedProject(project)
-        } catch (e) {
-            console.error('Error creating default project: ', error)
-        }
-    }
 
     const handleTaskSelect = (taskId) => {
         setIsDrawerOpen(true);
@@ -57,15 +38,9 @@ export const TaskPage = ({projectId}) => {
     }
 
     useEffect(() => {
-        authAndFetchProjects(setProjects)
-    }, []);
-
-    useEffect(() => {
-        if (projects == null)
+        if (projects == null || projects.length === 0)
             return
-        if (projects.length === 0)
-            return createDefaultProject()
-
+        
         if (isPresent(projectId)) {
             const p = projects.find(project => project.id === projectId)
             if (p) {
@@ -74,7 +49,7 @@ export const TaskPage = ({projectId}) => {
             }
             else
                 console.error('TODO: replace this with a 404 page')
-        } else
+        } else if (!selectedProject || projects.find(p => selectedProject.id === p.id) == undefined)
             setSelectedProject(projects[0])
 
         fetchTasks(setTasks)


### PR DESCRIPTION
fixes #109 and #123

switched to useContext for global project state, rather than having each component fetch projects themselves
to use projects going forward use:
```jsx
import { useContext } from 'react'
import { ProjectContext } from '@/lib/taskProjectUtils'
...
const { projects } = useContext(ProjectContext)
```

if your component needs to update projects add `addProject`, `deleteProject`, or (once they're added) `updateProject` or `trashProject` to the object returned by useContext. e.g.
```jsx
const { projects, addProject, deleteProject } = useContext(ProjectContext)
```